### PR TITLE
Add PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+## Proposed change/fix
+
+Describe your change/fix and tell us why we should accept it. Linking to the issue(s) is helpful too. If there is no outstanding issue, please create one in correspondence to this PR.
+
+## Types of changes
+
+What types of changes does this pull request introduce to ConsenSource? _Put an `x` in the boxes that apply_
+
+- [ ] Bugfix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Other (could be a small README update, documentation contribution, etc.)
+
+## How to run/test
+
+Please include instructions on how to run/test your contribution.
+Disregard this if your contribution is less technical (little to no code).


### PR DESCRIPTION
Add a GitHub template for PRs so that whenever a new PR is made it will follow the template's layout/design.