### PR TITLE
finish GET for a single user

### DIFF
--- a/api.py
+++ b/api.py
@@ -41,5 +41,14 @@ def tasks():
     all_tasks = {"tasks": tasks}
     return all_tasks #to return a json named tasks
 
+@app.route('/users/<username>')
+def user(username):
+    """A user endpoint for obtaining a single user information"""
+    print("Grabbing single user data")
+    conn = db.connect()
+    user = db.get_user(conn, str(username))
+    return json.dumps(user)
+
+
 if __name__ == '__main__':
     app.run()

--- a/db.py
+++ b/db.py
@@ -97,4 +97,27 @@ def db_row_to_dict_task(row: tuple) -> dict:
         ]
     return dict(zip(column_names, list(row)))
 
+def get_user(conn, username) -> List[dict]:
+    """Grab a single user from the database.
+    conn: psycopg2.extensions.connection object
+    Returns:
+    A list of python dicts containing THE user data
+    """
+    user = []
+    curr = conn.cursor()
+    curr.execute("SELECT username, name, email, points, role FROM users WHERE username='" + username + "';")
+    for row in curr.fetchall():
+        user.append(db_row_to_dict_single_user(row))
+    return user
 
+def db_row_to_dict_single_user(row: tuple) -> dict:
+    """Helper function to convert a tuple of data into a dict
+    row: tuple of user data
+
+    Returns:
+    A dict with db columns as the dict keys
+    """
+    column_names = [
+            "username", "name", "email", "points", "role"
+        ]
+    return dict(zip(column_names, list(row)))


### PR DESCRIPTION
## Proposed change/fix

Describe your change/fix and tell us why we should accept it. Linking to the issue(s) is helpful too. If there is no outstanding issue, please create one in correspondence to this PR.

I build up this new feature for GET request for /user/<username> with similar principle of the previous two GET request. The only change is the SQL query: since we want to access only one user, therefore a restricted WHERE is added into the query string.

## Types of changes

What types of changes does this pull request introduce to ConsenSource? _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (could be a small README update, documentation contribution, etc.)

## How to run/test

Please include instructions on how to run/test your contribution.
Disregard this if your contribution is less technical (little to no code).

1. Run the database first with test user in the database by "docker-compose up"
2. Open Insomnia and type in "http://localhost:5000/users/<username>" with the test user's username in the <username> field and click send (send GET request)
3. A json should be returned with username, name, email, points, role
